### PR TITLE
Change the method of recording number of test-ID

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -81,7 +81,7 @@ mod simple {
     /// Has no collisions
     #[test]
     fn no_collisions () {
-        let count = 100 * 1000;
+        let count = 10^5;
 
         let mut ids = HashMap::new();
 


### PR DESCRIPTION
Recording numbers on 84 line not evident and bad read.
Can  arise  questions, why there is multiplication and is there any some special meaning or optimization in this.
I picked up more evident and accessible recording method this large number.