### PR TITLE
Fix typo in function name

### DIFF
--- a/benches/random.rs
+++ b/benches/random.rs
@@ -11,6 +11,6 @@ fn os(b: &mut Bencher) {
 }
 
 #[bench]
-fn standart(b: &mut Bencher) {
-    b.iter(|| nanoid::random::standart(100));
+fn standard(b: &mut Bencher) {
+    b.iter(|| nanoid::random::standard(100));
 }

--- a/src/generator.rs
+++ b/src/generator.rs
@@ -57,7 +57,7 @@ mod test_fast {
         let lengths = [21, 5, 17, 134, 1];
 
         for &l in &lengths {
-            let id = fast(random::standart, &alphabet::SAFE, l);
+            let id = fast(random::standard, &alphabet::SAFE, l);
 
             assert_eq!(id.len(), l);
         }
@@ -66,7 +66,7 @@ mod test_fast {
     #[test]
     fn url_friendly () {
         for _ in 0..10 {
-            let id = fast(random::standart, &alphabet::SAFE, 21);
+            let id = fast(random::standard, &alphabet::SAFE, 21);
 
             for ch in id.chars() {
                 assert!(alphabet::SAFE.contains(&ch));
@@ -82,7 +82,7 @@ mod test_fast {
         let mut ids = HashSet::with_capacity(count);
 
         for _ in 0..count {
-            let id = fast(random::standart, &alphabet::SAFE, length);
+            let id = fast(random::standard, &alphabet::SAFE, length);
             assert!(ids.insert(id));
         }
     }
@@ -95,7 +95,7 @@ mod test_fast {
         let mut chars = HashMap::with_capacity(alphabet::SAFE.len());
 
         for _ in 0..count {
-            let id = fast(random::standart, &alphabet::SAFE, length);
+            let id = fast(random::standard, &alphabet::SAFE, length);
 
             for ch in id.chars() {
                 let counter = chars.entry(ch).or_insert(0);

--- a/src/random.rs
+++ b/src/random.rs
@@ -2,7 +2,7 @@ use rand;
 
 use rand::{Rng,OsRng,thread_rng};
 
-pub fn standart(size: usize) -> Vec<u8> {
+pub fn standard(size: usize) -> Vec<u8> {
     let mut result: Vec<u8> = vec![0; size];
 
     thread_rng().fill_bytes(&mut result);
@@ -11,12 +11,12 @@ pub fn standart(size: usize) -> Vec<u8> {
 }
 
 #[cfg(test)]
-mod test_standart {
+mod test_standard {
     use super::*;
 
     #[test]
     fn generates_random_vectors() {
-        let bytes = standart(5);
+        let bytes = standard(5);
 
         assert_eq!(bytes.len(), 5);
     }


### PR DESCRIPTION
Fix typo: `standart` -> `standard`