### PR TITLE
Remove the floating point computations from the sampling code

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -141,7 +141,7 @@ pub fn format(random: fn(usize) -> Vec<u8>, alphabet: &[char], size: usize) -> S
         "The alphabet cannot be longer than a `u8` (to comply with the `random` function)"
     );
 
-    let mask = (2 << ((alphabet.len() as f64 - 1.0).ln() / 2.0_f64.ln()) as i64) - 1;
+    let mask = alphabet.len().next_power_of_two() -1;
     let step: usize = (1.6_f64 * (mask * size) as f64).ceil() as usize;
 
     // Assert that the masking does not truncate the alphabet. (See #9)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,7 +142,7 @@ pub fn format(random: fn(usize) -> Vec<u8>, alphabet: &[char], size: usize) -> S
     );
 
     let mask = alphabet.len().next_power_of_two() -1;
-    let step: usize = (1.6_f64 * (mask * size) as f64).ceil() as usize;
+    let step: usize = 8 * size / 5;
 
     // Assert that the masking does not truncate the alphabet. (See #9)
     debug_assert!(alphabet.len() <= mask + 1);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,9 @@ pub fn format(random: fn(usize) -> Vec<u8>, alphabet: &[char], size: usize) -> S
     let mask = (2 << ((alphabet.len() as f64 - 1.0).ln() / 2.0_f64.ln()) as i64) - 1;
     let step: usize = (1.6_f64 * (mask * size) as f64).ceil() as usize;
 
+    // Assert that the masking does not truncate the alphabet. (See #9)
+    debug_assert!(alphabet.len() <= mask + 1);
+
     let mut id = String::with_capacity(size);
 
     loop {
@@ -182,6 +185,14 @@ mod test_format {
         let alphabet: Vec<char> = (0..32_u8).cycle().map(|i| i as char).take(1000).collect();
         nanoid!(21, &alphabet);
     }
+
+    #[test]
+    fn non_power_2() {
+        let id: String = nanoid!(42, &alphabet::SAFE[0..62]);
+
+        assert_eq!(id.len(), 42);
+    }
+
 }
 
 #[macro_export]


### PR DESCRIPTION
While working on #9, I discovered that my initial bug report seems incorrect; however, the code in `format` was needlessly complicated, so I had a first stab at simplifying it:
- [x] added a debug assertion and test that make it clear #9 is an incorrect bug report;
- [x] replaced the computation of `mask` with `std::usize::next_power_of_two`;
- [x] replaced the computation of `step` with a simple expression.

This PR should induce no functional changes.

Closes #9.