### PR TITLE
Specify explicit edition

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "nanoid"
 version = "0.3.0"
-authors = ["Nikolay Govorov<nikolay_govorov@bk.ru>"]
+authors = ["Nikolay Govorov <nikolay_govorov@bk.ru>"]
 license = "MIT"
 readme = "README.md"
 repository = "https://github.com/nikolay-govorov/nanoid.git"
@@ -10,6 +10,7 @@ homepage = "https://github.com/nikolay-govorov/nanoid"
 description = "A tiny, secure, URL-friendly, unique string ID generator for Rust."
 keywords = ["uuid", "random", "id", "url"]
 include = ["src/**/*", "Cargo.toml", "LICENSE", "README.md", "CHANGELOG.md"]
+edition = "2018"
 
 [badges]
 maintenance = { status = "actively-developed" }

--- a/benches/rngs.rs
+++ b/benches/rngs.rs
@@ -1,6 +1,5 @@
 #![feature(test)]
 
-extern crate nanoid;
 extern crate test;
 
 use test::Bencher;

--- a/examples/base.rs
+++ b/examples/base.rs
@@ -1,4 +1,3 @@
-extern crate nanoid;
 use nanoid::nanoid;
 
 fn main() {

--- a/examples/complex.rs
+++ b/examples/complex.rs
@@ -1,6 +1,3 @@
-extern crate nanoid;
-extern crate rand;
-
 use nanoid::nanoid;
 
 use rand::distributions::Standard;

--- a/examples/macros.rs
+++ b/examples/macros.rs
@@ -1,4 +1,3 @@
-extern crate nanoid;
 use nanoid::nanoid;
 
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,6 @@
 //! ```
 //!
 //! ```rust
-//! extern crate nanoid;
 //! use nanoid::nanoid;
 //!
 //! fn main() {
@@ -28,7 +27,6 @@
 //! with 21 characters.
 //!
 //! ```rust
-//! extern crate nanoid;
 //! use nanoid::nanoid;
 //!
 //! fn main() {
@@ -45,7 +43,6 @@
 //! you can pass the length as an argument generate function:
 //!
 //! ```rust
-//! extern crate nanoid;
 //! use nanoid::nanoid;
 //!
 //! fn main() {
@@ -59,7 +56,6 @@
 //! you can use the low-level `custom` module.
 //!
 //! ```rust
-//! extern crate nanoid;
 //! use nanoid::nanoid;
 //!
 //! fn main() {
@@ -80,7 +76,6 @@
 //! For instance, to use a seed-based generator.
 //!
 //! ```rust
-//! extern crate nanoid;
 //! use nanoid::nanoid;
 //!
 //! fn randomByte () -> u8 {
@@ -109,7 +104,6 @@
 //! you can get the default alphabet from the `url` module:
 //!
 //! ```rust
-//! extern crate nanoid;
 //! use nanoid::nanoid;
 //!
 //! fn random (size: usize) -> Vec<u8> {
@@ -129,8 +123,6 @@
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
     html_root_url = "https://docs.rs/nanoid"
 )]
-
-extern crate rand;
 
 pub mod alphabet;
 pub mod rngs;


### PR DESCRIPTION
You didn't specify the edition before which meant you used Rust 2018 by default. You should explicitly set it. Also, this means we should embrace 2018 edition and remove explicit `extern crate`s where not required.