### PR TITLE
Upgrade rand version from 0.6 to 0.7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ appveyor = { repository = "nikolay-govorov/nanoid", branch = "master", service =
 travis-ci = { repository = "nikolay-govorov/nanoid", branch = "master" }
 
 [dependencies]
-rand = "0.6"
+rand = { version = "0.7", features = ["small_rng"] }
 
 [dev-dependencies]
 cargo-husky = { version = "1", default-features = false, features = ["prepush-hook", "precommit-hook", "postmerge-hook", "run-cargo-test", "run-cargo-check", "run-cargo-clippy", "run-cargo-fmt"] }

--- a/src/rngs.rs
+++ b/src/rngs.rs
@@ -1,6 +1,6 @@
 use rand::{
     rngs::{SmallRng, StdRng},
-    FromEntropy, Rng,
+    Rng, SeedableRng,
 };
 
 pub fn default(size: usize) -> Vec<u8> {


### PR DESCRIPTION
`rand_core` v0.3.1 had an unsound advisory: https://rustsec.org/advisories/RUSTSEC-2019-0035.
Upgrading `rand` to 0.7 eliminates that as a side product.