### PR TITLE
Fix alphabet example in Rust doc comment.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,7 +3,7 @@
 //! **Safe.** It uses cryptographically strong random APIs
 //! and guarantees a proper distribution of symbols.
 //!
-//! **Compact.** It uses a larger alphabet than UUID (`A-Za-z0-9_~`)
+//! **Compact.** It uses a larger alphabet than UUID (`A-Za-z0-9_-`)
 //! and has a similar number of unique IDs in just 21 symbols instead of 36.
 //!
 //! ```toml
@@ -23,7 +23,7 @@
 //!
 //! ### Simple
 //!
-//! The main module uses URL-friendly symbols (`A-Za-z0-9_~`) and returns an ID
+//! The main module uses URL-friendly symbols (`A-Za-z0-9_-`) and returns an ID
 //! with 21 characters.
 //!
 //! ```rust


### PR DESCRIPTION
The documentation incorrectly specifies tilde (~) instead of hyphen (-).
PR changes `A-Za-z0-9_~` to `A-Za-z0-9_-` in Rust doc comment.

This tripped me up when writing a Regex for a nanoid, probably because it's late at night, I'm sure someone else will appreciate this too. Thank you.