### PR TITLE
Accept any expression as the size argument

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,17 +194,17 @@ macro_rules! nanoid {
     };
 
     // generate
-    ($size:tt) => {
+    ($size:expr) => {
         $crate::format($crate::rngs::default, &$crate::alphabet::SAFE, $size)
     };
 
     // custom
-    ($size:tt, $alphabet:expr) => {
+    ($size:expr, $alphabet:expr) => {
         $crate::format($crate::rngs::default, $alphabet, $size)
     };
 
     // complex
-    ($size:tt, $alphabet:expr, $random:expr) => {
+    ($size:expr, $alphabet:expr, $random:expr) => {
         $crate::format($random, $alphabet, $size)
     };
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -240,6 +240,13 @@ mod test_macros {
 
         assert_eq!(id.len(), 4);
     }
+
+    #[test]
+    fn simple_expression() {
+        let id: String = nanoid!(42 / 2);
+
+        assert_eq!(id.len(), 21);
+    }
 }
 
 #[cfg(doctest)]


### PR DESCRIPTION
Currently, the `nanoid!` macro only accepts a single token as its `size` argument. This means that expressions such as `some_path::SIZE`, `compute_size()`, and `42 / 2` will not compile.

This PR changes the macro to accept any expression as its `size` argument.