### PR TITLE
Add "smartstring" feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,11 @@ travis-ci = { repository = "nikolay-govorov/nanoid", branch = "master" }
 
 [dependencies]
 rand = { version = "0.8", features = ["small_rng"] }
+smartstring = { version = "1.0.1", optional = true }
 
 [dev-dependencies]
 cargo-husky = { version = "1", default-features = false, features = ["prepush-hook", "precommit-hook", "postmerge-hook", "run-cargo-test", "run-cargo-check", "run-cargo-clippy", "run-cargo-fmt"] }
 doc-comment = "0.3"
+
+[features]
+default = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -124,6 +124,9 @@
     html_root_url = "https://docs.rs/nanoid"
 )]
 
+#[cfg(feature = "smartstring")]
+use smartstring::alias::String;
+
 pub mod alphabet;
 pub mod rngs;
 
@@ -139,7 +142,10 @@ pub fn format(random: fn(usize) -> Vec<u8>, alphabet: &[char], size: usize) -> S
     // Assert that the masking does not truncate the alphabet. (See #9)
     debug_assert!(alphabet.len() <= mask + 1);
 
+    #[cfg(not(feature = "smartstring"))]
     let mut id = String::with_capacity(size);
+    #[cfg(feature = "smartstring")]
+    let mut id = String::new();
 
     loop {
         let bytes = random(step);


### PR DESCRIPTION
This PR adds support for generating smartstring::SmartString instead of normal Strings. This can avoid a heap allocation when the ID is smaller than 23 ASCII characters. (which is the case by default)
An initial capacity isn't supported by SmartString so I had to replace it with `String::new` when the feature is enabled.

More info: https://docs.rs/smartstring