### PR TITLE
Use correct character in example

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@
 //! use nanoid::nanoid;
 //!
 //! fn main() {
-//!    let id = nanoid!(10); //=> "IRFa~VaY2b"
+//!    let id = nanoid!(10); //=> "IRFa-VaY2b"
 //! }
 //! ```
 //!


### PR DESCRIPTION
~ is no longer part of the default alphabet.

Fixes #33